### PR TITLE
Updates data_router_config in target_config.json

### DIFF
--- a/config/target_config.json
+++ b/config/target_config.json
@@ -11,8 +11,10 @@
             "network_interfaces": [],
             "ecu_name": "s_core_ecu_qemu_bridge_network_pp",
             "data_router_config": {
-                "vlan_address": "127.0.0.1",
-                "multicast_addresses": []
+                "vlan_address": "192.168.122.1",
+                "multicast_addresses": [
+                    "239.255.42.99"
+                ]
             },
             "qemu_num_cores": 2,
             "qemu_ram_size": "1G"


### PR DESCRIPTION
- The vlan_address is the network interface the DLT receiver would use for joining multicast groups. The 192.168.122.1 ip is the host IP on the `virbr0` bridge
- Adds multicast address for DLT capture.