### PR TITLE
Making upload of symlinked file work on docker

### DIFF
--- a/score/itf/plugins/docker.py
+++ b/score/itf/plugins/docker.py
@@ -189,7 +189,7 @@ class DockerTarget(Target):
         remote_name = os.path.basename(remote_path)
 
         tar_stream = io.BytesIO()
-        with tarfile.open(fileobj=tar_stream, mode="w") as tar:
+        with tarfile.open(fileobj=tar_stream, mode="w", dereference=True) as tar:
             tar.add(local_path, arcname=remote_name)
         tar_stream.seek(0)
 


### PR DESCRIPTION
When uploading a symlinked file the current docker plugin uploads just the symlink file. With this change the actual file is uploaded.