### PR TITLE
Add env passthrough and inherit test attrs

### DIFF
--- a/bazel/py_itf_plugin.bzl
+++ b/bazel/py_itf_plugin.bzl
@@ -21,6 +21,7 @@ PyItfPluginInfo = provider(
         "resolved_args": "List of CLI args with $(location ...) pre-resolved.",
         "plugin_runfiles": "Merged runfiles from all plugin data dependencies.",
         "plugin_files": "Depset of all files contributed by the plugin.",
+        "env": "Dict of environment variables contributed by the plugin.",
     },
 )
 
@@ -53,6 +54,7 @@ def _py_itf_plugin_impl(ctx):
             resolved_args = resolved_args,
             plugin_runfiles = plugin_runfiles,
             plugin_files = all_plugin_files,
+            env = ctx.attr.env,
         ),
     ]
 
@@ -91,6 +93,10 @@ py_itf_plugin = rule(
             default = [],
             allow_files = True,
             cfg = "exec",
+        ),
+        "env": attr.string_dict(
+            doc = "Environment variables contributed by plugin to the test.",
+            default = {},
         ),
     },
 )

--- a/bazel/py_itf_test.bzl
+++ b/bazel/py_itf_test.bzl
@@ -132,13 +132,16 @@ def _itf_test_impl(ctx):
         transitive_files = depset(transitive = transitive),
     )
 
-    # Add plugin runfiles (carries plugin data files + py_library runfiles)
+    # Merge plugin runfiles (carries plugin data files + py_library runfiles) and envs
+    env = {}
     for plugin_target in ctx.attr.plugins:
         info = plugin_target[PyItfPluginInfo]
         runfiles = runfiles.merge(info.plugin_runfiles)
 
         # Also merge the DefaultInfo runfiles forwarded from py_library
         runfiles = runfiles.merge(plugin_target[DefaultInfo].default_runfiles)
+        env.update(info.env)
+    env.update(ctx.attr.env)
 
     return [
         DefaultInfo(
@@ -146,7 +149,7 @@ def _itf_test_impl(ctx):
             runfiles = runfiles,
         ),
         RunEnvironmentInfo(
-            environment = ctx.attr.env,
+            environment = env,
         ),
     ]
 
@@ -206,7 +209,7 @@ _itf_test = rule(
 # Symbolic macro: the public API, creates the py_test + _itf_test pair.
 # =============================================================================
 
-def _py_itf_test_impl(name, visibility, srcs, args, data, data_as_exec, plugins, deps, tags, pytest_config, **kwargs):
+def _py_itf_test_impl(name, visibility, srcs, args, data, data_as_exec, plugins, deps, tags, pytest_config, env, **kwargs):
     """Symbolic macro implementation for ITF tests."""
     pytest_bootstrap = Label("@score_itf//:main.py")
 
@@ -228,6 +231,8 @@ def _py_itf_test_impl(name, visibility, srcs, args, data, data_as_exec, plugins,
     )
 
     # Wrapper test rule: resolves plugin providers and launches the py_test.
+    # Test attrs (timeout, size, etc.) and common attrs (testonly, etc.) are
+    # inherited from _itf_test via inherit_attrs and forwarded via **kwargs.
     _itf_test(
         name = name,
         test_binary = name + ".test_binary",
@@ -239,14 +244,16 @@ def _py_itf_test_impl(name, visibility, srcs, args, data, data_as_exec, plugins,
         extra_args = args,
         env = {
             "PYTHONDONOTWRITEBYTECODE": "1",
-        },
+        } | env,
         tags = tags,
         visibility = visibility,
+        **kwargs
     )
 
 py_itf_test = macro(
     doc = "Symbolic macro for running ITF tests with pytest.",
     implementation = _py_itf_test_impl,
+    inherit_attrs = _itf_test,
     attrs = {
         "srcs": attr.label_list(mandatory = True, allow_files = [".py"]),
         "args": attr.string_list(default = []),
@@ -255,6 +262,9 @@ py_itf_test = macro(
         "plugins": attr.label_list(default = [], providers = [PyItfPluginInfo]),
         "deps": attr.label_list(default = [], providers = [PyInfo]),
         "pytest_config": attr.label(default = None, allow_single_file = True, doc = "Custom pytest configuration file. If not specified, uses the default from @score_itf//:pytest.ini."),
+        "env": attr.string_dict(default = {}, doc = "Environment variables for the test."),
+        # Suppress internal _itf_test attrs that are not part of the public API.
+        "test_binary": None,
+        "extra_args": None,
     },
-    inherit_attrs = "common",
 )

--- a/score/itf/plugins/docker.py
+++ b/score/itf/plugins/docker.py
@@ -30,6 +30,9 @@ from score.itf.plugins.core import Target
 
 logger = logging.getLogger(__name__)
 
+# Default timeout (seconds) for Docker client operations.
+DOCKER_CLIENT_TIMEOUT = 180
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -119,7 +122,7 @@ class DockerTarget(Target):
     def __init__(self, container):
         super().__init__()
         self.container = container
-        self._client = pypi_docker.from_env()
+        self._client = pypi_docker.from_env(timeout=DOCKER_CLIENT_TIMEOUT)
 
     def __getattr__(self, name):
         return getattr(self.container, name)
@@ -155,10 +158,9 @@ class DockerTarget(Target):
             workdir=cwd,
         )
         exec_id = exec_instance["Id"]
-        stream = self._client.api.exec_start(exec_id, stream=True)
-        first_chunk = next(stream).decode()
-        pid_line, _, remainder = first_chunk.partition("\n")
-        pid = int(pid_line.strip())
+        # demux=True delivers stdout/stderr as separate (bytes|None, bytes|None)
+        # tuples, preventing early stderr from the child from masking the PID.
+        stream = self._client.api.exec_start(exec_id, stream=True, demux=True)
 
         cmd_logger = logging.getLogger(os.path.basename(command.split()[0]))
         output_lines = []
@@ -169,12 +171,26 @@ class DockerTarget(Target):
                     cmd_logger.info(line)
                     output_lines.append(line)
 
-        if remainder.strip():
-            _process_text(remainder)
+        pid = None
+        for stdout_chunk, stderr_chunk in stream:
+            if stderr_chunk:
+                _process_text(stderr_chunk.decode())
+            if stdout_chunk:
+                pid_line, _, remainder = stdout_chunk.decode().partition("\n")
+                pid = int(pid_line.strip())
+                if remainder.strip():
+                    _process_text(remainder)
+                break
+
+        if pid is None:
+            raise RuntimeError(f"Failed to extract PID from stdout for '{command}'")
 
         def _async_log(log_stream):
-            for chunk in log_stream:
-                _process_text(chunk.decode())
+            for stdout_chunk, stderr_chunk in log_stream:
+                if stdout_chunk:
+                    _process_text(stdout_chunk.decode())
+                if stderr_chunk:
+                    _process_text(stderr_chunk.decode())
 
         output_thread = threading.Thread(target=_async_log, args=(stream,), daemon=True)
         output_thread.start()
@@ -254,6 +270,7 @@ def _docker_configuration(docker_configuration):
         "environment": {},
         "command": "sleep infinity",
         "init": True,
+        "shm_size": "2G",
         "volumes": {},
     }
     merged_configuration = {**configuration, **docker_configuration}
@@ -271,7 +288,7 @@ def target_init(request, _docker_configuration):
         subprocess.run([docker_image_bootstrap], check=True)
 
     docker_image = request.config.getoption("docker_image")
-    client = pypi_docker.from_env()
+    client = pypi_docker.from_env(timeout=DOCKER_CLIENT_TIMEOUT)
     container = client.containers.run(
         docker_image,
         _docker_configuration["command"],
@@ -280,6 +297,7 @@ def target_init(request, _docker_configuration):
         init=_docker_configuration["init"],
         environment=_docker_configuration["environment"],
         volumes=_docker_configuration["volumes"],
+        shm_size=_docker_configuration["shm_size"],
     )
     try:
         yield DockerTarget(container)


### PR DESCRIPTION
Enable setting env vars via tests and plugins
Enable use of test attrs (timeout, size, flaky etc.)
Split docker stream into stdout & stderr
Set docker client timeout
Set docker default shm size