### PR TITLE
Restore terminal margin setting after qemu finish

### DIFF
--- a/scripts/run_under_qemu.sh
+++ b/scripts/run_under_qemu.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # *******************************************************************************
 # Copyright (c) 2025 Contributors to the Eclipse Foundation
 #
@@ -11,8 +12,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-#!/bin/bash
 set -euo pipefail
+
+# Restore terminal auto-margin setting, corrupted by QEMU output
+trap 'tput -T xterm smam 2>/dev/null || true' EXIT
 
 # Check if TEST_UNDECLARED_OUTPUTS_DIR is set
 CMD_UNDECLARED_OUTPUTS_DIR="true"


### PR DESCRIPTION
Fix QEMU output corrupting terminal setting
Move shebang to the start of the file