### PR TITLE
Strip DEC Private Mode sequences from QEMU output

### DIFF
--- a/score/itf/core/process/console.py
+++ b/score/itf/core/process/console.py
@@ -380,6 +380,9 @@ def try_to_encode(data, encoding="ascii"):
 def try_to_decode(data, encoding="ascii"):
     if isinstance(data, bytes):
         data = re.sub(b"\r[^\n]", b"", data)
+        # Strip VT100 DEC Private Mode sequences (e.g. \e[?7l disabling auto-wrap)
+        # that corrupt the terminal when Bazel replays captured test output.
+        data = re.sub(b"\033\\[\\?[0-9;]*[hl]", b"", data)
         return data.decode(encoding, "replace").rstrip("\n").rstrip("\r")
     if isinstance(data, str):
         return data.rstrip("\n").rstrip("\r")

--- a/scripts/run_under_qemu.sh
+++ b/scripts/run_under_qemu.sh
@@ -14,9 +14,6 @@
 
 set -euo pipefail
 
-# Restore terminal auto-margin setting, corrupted by QEMU output
-trap 'tput -T xterm smam 2>/dev/null || true' EXIT
-
 # Check if TEST_UNDECLARED_OUTPUTS_DIR is set
 CMD_UNDECLARED_OUTPUTS_DIR="true"
 if [[ -n "${TEST_UNDECLARED_OUTPUTS_DIR:-}" ]]; then


### PR DESCRIPTION
Prevent the corruption of terminal settings from reaching the test log.
Enable the fix in workspaces which depend on score_itf bazel module.
Remove redundant trap.