### PR TITLE
fix(docker): forward extra config keys to containers.run()

### DIFF
--- a/score/itf/plugins/docker.py
+++ b/score/itf/plugins/docker.py
@@ -322,6 +322,11 @@ def target_init(request, _docker_configuration):
 
     docker_image = request.config.getoption("docker_image")
     client = pypi_docker.from_env(timeout=DOCKER_CLIENT_TIMEOUT)
+    known_keys = {"command", "init", "environment", "volumes", "shm_size", "detach", "auto_remove"}
+    reserved_overrides = {k for k in ("detach", "auto_remove") if k in _docker_configuration}
+    if reserved_overrides:
+        logger.warning(f"docker_configuration contains reserved keys {reserved_overrides} which will be ignored")
+    extra_kwargs = {k: v for k, v in _docker_configuration.items() if k not in known_keys}
     container = client.containers.run(
         docker_image,
         _docker_configuration["command"],
@@ -331,6 +336,7 @@ def target_init(request, _docker_configuration):
         environment=_docker_configuration["environment"],
         volumes=_docker_configuration["volumes"],
         shm_size=_docker_configuration["shm_size"],
+        **extra_kwargs,
     )
     target = None
     try:


### PR DESCRIPTION
target_init hard-coded only the known keys (command, init, environment, volumes, shm_size) when calling client.containers.run(), silently dropping anything else the test supplied via the docker_configuration fixture — including network_mode.

Collect the remainder into extra_kwargs and unpack them into the call so that tests can pass arbitrary Docker SDK parameters (e.g. network_mode="host") without modifying the plugin.