### PR TITLE
Remove paramiko.DSSKey

### DIFF
--- a/score/itf/core/com/ssh.py
+++ b/score/itf/core/com/ssh.py
@@ -66,7 +66,6 @@ class Ssh:
             paramiko.RSAKey,
             paramiko.ECDSAKey,
             paramiko.Ed25519Key,
-            paramiko.DSSKey,
         ]
 
         load_errors = []


### PR DESCRIPTION
DSSKey has been deprecated from OpenSSH for 10 years and is no longer supported by paramiko.