### PR TITLE
fix: Correctly pass accelerator parameters to QEMU

### DIFF
--- a/score/itf/plugins/qemu/qemu.py
+++ b/score/itf/plugins/qemu/qemu.py
@@ -107,12 +107,13 @@ class Qemu:
                 sys.exit(-1)
 
     def __build_qemu_command(self):
+        # Use hardware virtualization if available
+        accel = ["-enable-kvm"] if self._accelerator_support == "kvm" else ["-accel", "tcg"]
+
         return (
-            [
-                f"{self.__qemu_path}",
-                "--enable-kvm"
-                if self._accelerator_support == "kvm"
-                else " -accel tcg",  # Use hardware virtualization if available
+            [f"{self.__qemu_path}"]
+            + accel
+            + [
                 "-smp",
                 f"{self.__cores},maxcpus={self.__cores},cores={self.__cores}",
                 "-cpu",


### PR DESCRIPTION
Documentation of QEMU states that `-enable-kvm` is the publicly known way to enable KVM. However `--enable-kvm` also seems to work, but is not documented.

Passing `-accel tcg` as a single string might fail QEMU to recognize the argument.