### PR TITLE
fix(bazel): use Label() for deps in py_itf_unittest

### DIFF
--- a/bazel/py_itf_unittest.bzl
+++ b/bazel/py_itf_unittest.bzl
@@ -44,7 +44,7 @@ def py_itf_unittest(name, srcs, deps = [], data = [], env = {}, pytest_config = 
             "--show-capture=no",
             "--junitxml=$$XML_OUTPUT_FILE",
         ] + ["$(location %s)" % x for x in srcs],
-        deps = ["@score_itf//:itf", "@itf_pip//pytest_mock"] + deps,
+        deps = [Label("@score_itf//:itf"), Label("@itf_pip//pytest_mock")] + deps,
         data = [pytest_config] + data,
         env = {"PYTHONDONOTWRITEBYTECODE": "1"} | env,
         **kwargs


### PR DESCRIPTION
## Summary

The `py_itf_unittest` macro passes `"@score_itf//:itf"` and `"@itf_pip//pytest_mock"` as string labels in the `deps` list of `py_test`. In Bazel's bzlmod, string labels inside legacy (def-based) macros are resolved in the **caller's repository context**, not the defining module's. This means `@itf_pip` is looked up in the downstream consumer's repo, where it does not exist.

The fix wraps both labels with `Label()`, which is evaluated at `.bzl` load time and resolves in **score_itf's module context**, where `itf_pip` is always defined.

This is consistent with how `pytest_bootstrap` and `pytest_config` are already handled in the same file (lines 33-35).

## Problem

Any downstream module that uses `py_itf_unittest` fails at analysis time:

```
ERROR: no such package '@@[unknown repo 'itf_pip' requested from @@]//pytest_mock':
  The repository '@@[unknown repo 'itf_pip']' could not be resolved:
  No repository visible as '@itf_pip' from main repository
```

The only workaround is for every consumer to add `use_repo(pip, "itf_pip")` to their own `MODULE.bazel`, leaking an internal implementation detail of score_itf into all downstream modules.

## Benefits

- **Downstream consumers no longer need to know about `@itf_pip`.** The pip hub name is an internal detail of score_itf. Consumers should only need `bazel_dep(name = "score_itf", ...)` to use any public macro.

- **Consistent with the rest of the file.** `pytest_bootstrap` and `pytest_config` already use `Label()`. The `deps` list was the only place still using raw strings for cross-module references.

- **No behavioral change for score_itf's own tests.** `Label("@itf_pip//...")` resolves to the same target within score_itf as the string `"@itf_pip//..."` does today. The fix only changes resolution behavior when the macro is called from a different module.